### PR TITLE
Changed homepage loading code

### DIFF
--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -202,17 +202,19 @@
     <div *ngFor="let item of images; let i = index" class="masonry-item" (click)="openLightbox(i)">
       <video
         *ngIf="item.endsWith('.mp4')"
-        [src]="'/assets/showcase/full/' + item"
+        [src]="'/assets/showcase/tiny/' + item"
         autoplay
         loop
         muted
         playsinline
+        loading="lazy"
         class="masonry-media"
       ></video>
       <img
         *ngIf="!item.endsWith('.mp4')"
-        [src]="'/assets/showcase/full/' + item"
+        [src]="'/assets/showcase/tiny/' + item"
         [alt]="'Screenshot ' + item"
+        loading="lazy"
         class="masonry-media"
       />
     </div>


### PR DESCRIPTION
Instead of loading the full resolution images as thumbnails, now uses the "tiny" versions of them to save on bandwidth, also added lazy loading. 

unsure if this will fix the loading issue in itself, but if it loads - it will now load faster  