### PR TITLE
feat: add URL flag to control dev warning visibility

### DIFF
--- a/frontend/src/app/components/domain-warning/domain-warning.component.ts
+++ b/frontend/src/app/components/domain-warning/domain-warning.component.ts
@@ -11,6 +11,7 @@ export class DomainWarningComponent implements OnInit {
   showWarning = false;
   clickCount = 0;
   private readonly STORAGE_KEY = 'domain-warning-dismissed';
+  private readonly URL_FLAG = 'hideDev';
   private readonly PRODUCTION_DOMAIN = 'zeitvertreib.vip';
 
   ngOnInit(): void {
@@ -20,8 +21,16 @@ export class DomainWarningComponent implements OnInit {
   private checkDomain(): void {
     const hostname = window.location.hostname;
     const isDevelopment = hostname === 'dev.zeitvertreib.vip' || hostname === 'localhost';
+    const urlParams = new URLSearchParams(window.location.search);
+    const hideWarningFlag = urlParams.get(this.URL_FLAG);
 
     if (isDevelopment) {
+      if (hideWarningFlag !== null && hideWarningFlag !== 'false') {
+        sessionStorage.setItem(this.STORAGE_KEY, 'true');
+        this.showWarning = false;
+        return;
+      }
+
       const dismissed = sessionStorage.getItem(this.STORAGE_KEY);
       this.showWarning = !dismissed;
     }


### PR DESCRIPTION
the "experimental version" popup works too well, this feature allows you to send users a link to the dev branch without the trouble of the user clicking the wrong button over and over again! 

flag is `hideDev`